### PR TITLE
add angular 1 and material 1 CDN into default layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,16 +13,13 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: Your awesome title
-email: your-email@domain.com
-description: > # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+title: Tom's GitHub Portfolio
+email: tomdinhnz@gmail.com
+description: This site for blogging my projects
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://example.com" # the base hostname & protocol for your site
-twitter_username: jekyllrb
-github_username:  jekyll
+url: "" # the base hostname & protocol for your site
+twitter_username: tomdinhnz
+github_username:  tom031
 
 # Build settings
 markdown: kramdown

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{site.title}}</title>
+    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/angular_material/1.1.1/angular-material.min.css">
+  </head>
+  <body ng-app>
+    <h1>{{site.title}}</h1>
+    <md-title>This is title on angular_material</md-title>
+    {{ content }}
+
+    <h5>{{site.description}}</h5>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular-animate.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular-aria.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angular_material/1.1.1/angular-material.min.js"></script>
+    </body>
+</html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+{{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+{{ content }}


### PR DESCRIPTION
Starting Front end with Angular 1.5.8. This PR improve issue #14 and continue with Grid system from ngMaterial.